### PR TITLE
Fix #5 Implement production middleware suite for message processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ go get github.com/vsys-soham/natsx
 |---|---|
 | **One-liner connect** | Sensible defaults, zero boilerplate |
 | **Functional options** | `WithURL`, `WithAuth`, `WithTLS` … extensible without breaking |
-| **Pub / Sub / Request** | Raw bytes, JSON, headers — all covered |
+| **Pub / Sub / Request** | Raw bytes, JSON, context-aware, headers — all covered |
 | **Queue groups** | Built-in load-balanced subscriptions |
 | **JetStream** | First-class publish, subscribe, pull-subscribe via `jetstream` package |
-| **Middleware** | Composable handler chain — recovery, logging, custom via `middleware` package |
+| **Middleware** | Composable chain — recovery, logging, timeout, metrics, tracing, correlation-ID, concurrency limit, validation |
+| **Retry / Backoff** | Exponential backoff with jitter, permanent error classification |
+| **Subject validation** | Catches malformed subjects before they hit the wire |
+| **Error classification** | `IsRetryable()` separates transient from permanent failures |
 | **Pluggable logger** | `Logger` interface — works with slog, zap, zerolog |
 | **Health checks** | `IsConnected()`, `Status()`, `Stats()` |
 | **Graceful shutdown** | `Close()` and `Drain()` |
@@ -25,12 +28,13 @@ go get github.com/vsys-soham/natsx
 ## Package Layout
 
 ```
-natsx/                      # Core client: connect, publish, subscribe, request
-├── middleware/              # Built-in middleware: Recovery, Logging
-├── jetstream/               # JetStream helpers: publish, subscribe, pull-subscribe
+natsx/                        # Core client: connect, publish, subscribe, request
+├── middleware/               # Built-in middleware (8 middlewares)
+├── jetstream/                # JetStream helpers: publish, subscribe, pull-subscribe
+├── retry/                    # Retry policies with exponential backoff + jitter
 └── examples/
-    ├── basic/main.go        # Core NATS demo
-    └── jetstream/main.go    # JetStream demo
+    ├── basic/main.go         # Core NATS demo
+    └── jetstream/main.go     # JetStream demo
 ```
 
 ---
@@ -61,20 +65,26 @@ func main() {
     }
     defer c.Drain()
 
-    // Subscribe with middleware
+    // Subscribe with middleware stack
     c.Subscribe("greet.*", func(msg *natsx.Msg) {
-        fmt.Printf("[%s] %s\n", msg.Subject, msg.Data)
-    }, middleware.Recovery(c.Log()))
+        cid := middleware.GetCorrelationID(msg.Context())
+        fmt.Printf("[%s] cid=%s %s\n", msg.Subject, cid, msg.Data)
+    },
+        middleware.Recovery(c.Log()),
+        middleware.Timeout(5*time.Second, c.Log()),
+        middleware.CorrelationID("", nil),
+        middleware.Metrics(middleware.NopMetrics{}),
+    )
 
-    // Publish
-    c.Publish("greet.world", []byte("Hello!"))
-    c.PublishJSON("greet.json", map[string]string{"hi": "there"})
+    // Publish (context-aware)
+    ctx := context.Background()
+    c.PublishJSONCtx(ctx, "greet.world", map[string]string{"hi": "there"})
 
     // Request / Reply
     c.Subscribe("echo", func(msg *natsx.Msg) {
         msg.Respond(msg.Data)
     })
-    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    ctx, cancel := context.WithTimeout(ctx, time.Second)
     defer cancel()
     reply, _ := c.Request(ctx, "echo", []byte("ping"))
     fmt.Println(string(reply.Data)) // "ping"
@@ -83,7 +93,7 @@ func main() {
 
 ---
 
-## API Cheatsheet
+## API Reference
 
 ### Connection
 
@@ -99,40 +109,36 @@ c.Log()  Logger              // get client logger
 ### Configuration Options
 
 ```go
-natsx.WithURL(url)
-natsx.WithName(name)
-natsx.WithToken(token)
-natsx.WithUserPass(user, pass)
-natsx.WithCredsFile(path)
-natsx.WithNKeyFile(path)
-natsx.WithTLS(tlsConfig)
-natsx.WithMaxReconnects(n)
-natsx.WithReconnectWait(d)
-natsx.WithConnectTimeout(d)
-natsx.WithDrainTimeout(d)
-natsx.WithPingInterval(d)
-natsx.WithLogger(logger)
-natsx.WithOnDisconnect(fn)
-natsx.WithOnReconnect(fn)
-natsx.WithOnClose(fn)
+natsx.WithURL(url)              natsx.WithName(name)
+natsx.WithToken(token)          natsx.WithUserPass(user, pass)
+natsx.WithCredsFile(path)       natsx.WithNKeyFile(path)
+natsx.WithTLS(tlsConfig)        natsx.WithMaxReconnects(n)
+natsx.WithReconnectWait(d)      natsx.WithConnectTimeout(d)
+natsx.WithDrainTimeout(d)       natsx.WithPingInterval(d)
+natsx.WithLogger(logger)        natsx.WithOnDisconnect(fn)
+natsx.WithOnReconnect(fn)       natsx.WithOnClose(fn)
 natsx.WithOnError(fn)
 ```
 
 ### Publishing
 
 ```go
-c.Publish(subject, data)            error
-c.PublishJSON(subject, v)           error
-c.PublishMsg(msg)                   error
-c.PublishWithHeaders(subj, hdr, d)  error
+c.Publish(subject, data)                 error   // raw bytes
+c.PublishCtx(ctx, subject, data)         error   // context-aware
+c.PublishJSON(subject, v)                error   // JSON marshal
+c.PublishJSONCtx(ctx, subject, v)        error   // JSON + context
+c.PublishMsg(msg)                        error   // custom nats.Msg
+c.PublishWithHeaders(subj, hdr, data)    error   // with headers
 ```
+
+All publish methods validate subjects automatically.
 
 ### Subscribing
 
 ```go
-c.Subscribe(subj, handler, mw...)          (*nats.Subscription, error)
+c.Subscribe(subj, handler, mw...)              (*nats.Subscription, error)
 c.QueueSubscribe(subj, queue, handler, mw...)  (*nats.Subscription, error)
-c.SubscribeChan(subj, ch)                  (*nats.Subscription, error)
+c.SubscribeChan(subj, ch)                      (*nats.Subscription, error)
 ```
 
 ### Request / Reply
@@ -140,6 +146,28 @@ c.SubscribeChan(subj, ch)                  (*nats.Subscription, error)
 ```go
 c.Request(ctx, subj, data)             (*Msg, error)
 c.RequestJSON(ctx, subj, req, &resp)   error
+```
+
+### Msg Helpers
+
+```go
+msg.Decode(&v)              error              // JSON unmarshal
+msg.RespondJSON(v)          error              // JSON reply
+msg.Respond(data)           error              // raw reply
+msg.Context()               context.Context    // get message context
+msg.WithContext(ctx)        *Msg               // set message context
+```
+
+### Subject Validation
+
+```go
+natsx.ValidateSubject(subject) error  // empty, whitespace, bad dots
+```
+
+### Error Classification
+
+```go
+natsx.IsRetryable(err) bool  // true for timeouts, disconnects; false for encoding, validation
 ```
 
 ### JetStream (`github.com/vsys-soham/natsx/jetstream`)
@@ -153,23 +181,61 @@ js.Subscribe(subj, handler, opts...)         (*nats.Subscription, error)
 js.PullSubscribe(subj, durable, opts...)     (*nats.Subscription, error)
 ```
 
-### Msg Helpers
+### Retry (`github.com/vsys-soham/natsx/retry`)
 
 ```go
-msg.Decode(&v)        error   // JSON unmarshal
-msg.RespondJSON(v)    error   // JSON reply
-msg.Respond(data)     error   // raw reply
+p := retry.DefaultPolicy()        // 3 attempts, 100ms initial, 2x multiplier, 0.2 jitter
+p := retry.NoRetry()              // single attempt
+
+result := retry.Do(ctx, p, func(ctx context.Context, attempt int) error {
+    return c.PublishCtx(ctx, "orders.new", data)
+})
+// result.Attempts, result.Err
+
+// Mark errors as non-retryable
+return &retry.Permanent{Err: ErrBadInput}
+retry.IsPermanent(err)             // check
+retry.ClassifyPermanent(err) bool  // use as Policy.Classifier
 ```
 
 ### Middleware (`github.com/vsys-soham/natsx/middleware`)
 
 ```go
-// Core (root package)
-natsx.Chain(handler, mw1, mw2)         MsgHandler
+// Chain applies middlewares in order (first = outermost)
+natsx.Chain(handler, mw1, mw2)
 
 // Built-in middleware
-middleware.Recovery(logger)            Middleware  // catch panics
-middleware.Logging(logger)             Middleware  // log messages
+middleware.Recovery(logger)                         // catch panics
+middleware.Logging(logger)                          // log each message
+middleware.Timeout(duration, logger)                // deadline + warning
+middleware.CorrelationID(header, generateFn)        // extract/inject correlation ID
+middleware.ConcurrencyLimit(maxInFlight)             // semaphore limiter
+middleware.Validation(validatorFn, onRejectFn)       // pre-handler validation
+middleware.Metrics(recorder)                         // counters + histograms
+middleware.Tracing(tracer, operationName)             // distributed tracing spans
+
+// Retrieve values set by middleware
+middleware.GetCorrelationID(ctx) string
+middleware.GetSpanContext(ctx)   SpanContext
+```
+
+**Metrics** uses the `MetricsRecorder` interface — implement for Prometheus, OTel, StatsD, etc.:
+
+```go
+type MetricsRecorder interface {
+    IncMessagesReceived(subject string)
+    IncMessagesProcessed(subject string)
+    IncMessagesFailed(subject string)
+    ObserveDuration(subject string, duration time.Duration)
+}
+```
+
+**Tracing** uses the `Tracer` interface — implement for OpenTelemetry, Jaeger, etc.:
+
+```go
+type Tracer interface {
+    StartSpan(ctx context.Context, op string, msg *natsx.Msg) (context.Context, SpanContext, func())
+}
 ```
 
 ### Health
@@ -189,17 +255,22 @@ c.ConnectedServerID()  string
 Write your own middleware with the `natsx.Middleware` type:
 
 ```go
-func Tracing() natsx.Middleware {
+func RateLimit(rps int) natsx.Middleware {
+    limiter := rate.NewLimiter(rate.Limit(rps), rps)
     return func(next natsx.MsgHandler) natsx.MsgHandler {
         return func(msg *natsx.Msg) {
-            start := time.Now()
+            limiter.Wait(msg.Context())
             next(msg)
-            log.Printf("[%s] %v", msg.Subject, time.Since(start))
         }
     }
 }
 
-c.Subscribe("events.>", handler, middleware.Recovery(log), Tracing())
+c.Subscribe("events.>", handler,
+    middleware.Recovery(log),
+    middleware.Timeout(5*time.Second, log),
+    middleware.Metrics(myRecorder),
+    RateLimit(100),
+)
 ```
 
 ---

--- a/middleware/concurrency.go
+++ b/middleware/concurrency.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"github.com/vsys-soham/natsx"
+)
+
+// ConcurrencyLimit returns a middleware that limits how many messages can be
+// processed concurrently. When the limit is reached, additional messages block
+// until a slot becomes available.
+//
+// This is useful for protecting downstream resources (databases, APIs) from
+// being overwhelmed by a burst of messages.
+func ConcurrencyLimit(maxConcurrent int) natsx.Middleware {
+	sem := make(chan struct{}, maxConcurrent)
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			next(msg)
+		}
+	}
+}

--- a/middleware/correlation.go
+++ b/middleware/correlation.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/vsys-soham/natsx"
+)
+
+// correlationIDKey is the context key for the correlation ID.
+type correlationIDKey struct{}
+
+// DefaultCorrelationHeader is the NATS header used for correlation IDs.
+const DefaultCorrelationHeader = "X-Correlation-ID"
+
+// CorrelationID returns a middleware that extracts a correlation ID from the
+// message header and stores it in the message context.
+//
+// If no correlation ID is present in the header, the optional generate function
+// is called to create one. If generate is nil and no header is found, no
+// correlation ID is set.
+func CorrelationID(header string, generate func() string) natsx.Middleware {
+	if header == "" {
+		header = DefaultCorrelationHeader
+	}
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			cid := msg.Header.Get(header)
+			if cid == "" && generate != nil {
+				cid = generate()
+			}
+			if cid != "" {
+				ctx := context.WithValue(msg.Context(), correlationIDKey{}, cid)
+				msg = msg.WithContext(ctx)
+			}
+			next(msg)
+		}
+	}
+}
+
+// GetCorrelationID extracts the correlation ID from a context.
+// Returns an empty string if no correlation ID is set.
+func GetCorrelationID(ctx context.Context) string {
+	if v, ok := ctx.Value(correlationIDKey{}).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/vsys-soham/natsx"
+)
+
+// MetricsRecorder is an interface for recording message processing metrics.
+// Implement this interface to integrate with your metrics backend (Prometheus,
+// OTel, StatsD, etc.) without coupling the middleware to a specific library.
+type MetricsRecorder interface {
+	// IncMessagesReceived increments the counter for received messages.
+	IncMessagesReceived(subject string)
+
+	// IncMessagesProcessed increments the counter for successfully processed messages.
+	IncMessagesProcessed(subject string)
+
+	// IncMessagesFailed increments the counter for failed messages (handler panicked).
+	IncMessagesFailed(subject string)
+
+	// ObserveDuration records the duration of message processing.
+	ObserveDuration(subject string, duration time.Duration)
+}
+
+// Metrics returns a middleware that records message processing metrics using
+// the provided MetricsRecorder. It captures:
+//   - messages received (before handler)
+//   - messages processed / failed (after handler, detecting panics)
+//   - processing duration histogram
+//
+// Panics are re-raised after recording the failure metric. Pair with Recovery
+// middleware (placed before Metrics in the chain) to catch panics, or let them
+// propagate if you want to crash on unhandled panics.
+func Metrics(recorder MetricsRecorder) natsx.Middleware {
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			subject := msg.Subject
+			recorder.IncMessagesReceived(subject)
+
+			start := time.Now()
+			panicked := true
+
+			defer func() {
+				duration := time.Since(start)
+				recorder.ObserveDuration(subject, duration)
+				if panicked {
+					recorder.IncMessagesFailed(subject)
+				} else {
+					recorder.IncMessagesProcessed(subject)
+				}
+			}()
+
+			next(msg)
+			panicked = false
+		}
+	}
+}
+
+// NopMetrics is a no-op MetricsRecorder. Useful for tests and as a default.
+type NopMetrics struct{}
+
+func (NopMetrics) IncMessagesReceived(string)            {}
+func (NopMetrics) IncMessagesProcessed(string)           {}
+func (NopMetrics) IncMessagesFailed(string)              {}
+func (NopMetrics) ObserveDuration(string, time.Duration) {}

--- a/middleware/middleware_ext_test.go
+++ b/middleware/middleware_ext_test.go
@@ -1,0 +1,443 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	natslib "github.com/nats-io/nats.go"
+	"github.com/vsys-soham/natsx"
+	"github.com/vsys-soham/natsx/middleware"
+)
+
+// ---------- Timeout ----------
+
+func TestTimeoutCompletes(t *testing.T) {
+	log := natsx.NopLogger{}
+	done := make(chan struct{})
+
+	handler := func(m *natsx.Msg) {
+		close(done)
+	}
+
+	mw := natsx.Chain(handler, middleware.Timeout(time.Second, log))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.timeout"}}
+	mw(msg)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler should have completed")
+	}
+}
+
+func TestTimeoutExceeded(t *testing.T) {
+	log := natsx.NopLogger{}
+
+	handler := func(m *natsx.Msg) {
+		// Handler checks context for cooperative cancellation.
+		<-m.Context().Done()
+	}
+
+	mw := natsx.Chain(handler, middleware.Timeout(50*time.Millisecond, log))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.timeout.slow"}}
+
+	start := time.Now()
+	mw(msg)
+	elapsed := time.Since(start)
+
+	// Should have finished around the timeout duration.
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("expected ~50ms, got %v", elapsed)
+	}
+}
+
+func TestTimeoutContextPropagated(t *testing.T) {
+	log := natsx.NopLogger{}
+	var hasDeadline bool
+
+	handler := func(m *natsx.Msg) {
+		_, hasDeadline = m.Context().Deadline()
+	}
+
+	mw := natsx.Chain(handler, middleware.Timeout(time.Second, log))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.timeout.ctx"}}
+	mw(msg)
+
+	if !hasDeadline {
+		t.Fatal("expected context to have a deadline")
+	}
+}
+
+// ---------- CorrelationID ----------
+
+func TestCorrelationIDFromHeader(t *testing.T) {
+	var capturedCID string
+
+	handler := func(m *natsx.Msg) {
+		capturedCID = middleware.GetCorrelationID(m.Context())
+	}
+
+	mw := natsx.Chain(handler, middleware.CorrelationID("", nil))
+
+	msg := &natsx.Msg{Msg: &natslib.Msg{
+		Subject: "test.cid",
+		Header:  natslib.Header{"X-Correlation-ID": []string{"abc-123"}},
+	}}
+	mw(msg)
+
+	if capturedCID != "abc-123" {
+		t.Fatalf("expected cid=abc-123, got %q", capturedCID)
+	}
+}
+
+func TestCorrelationIDGenerated(t *testing.T) {
+	var capturedCID string
+
+	handler := func(m *natsx.Msg) {
+		capturedCID = middleware.GetCorrelationID(m.Context())
+	}
+
+	gen := func() string { return "gen-456" }
+	mw := natsx.Chain(handler, middleware.CorrelationID("", gen))
+
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.cid.gen"}}
+	mw(msg)
+
+	if capturedCID != "gen-456" {
+		t.Fatalf("expected cid=gen-456, got %q", capturedCID)
+	}
+}
+
+func TestCorrelationIDCustomHeader(t *testing.T) {
+	var capturedCID string
+
+	handler := func(m *natsx.Msg) {
+		capturedCID = middleware.GetCorrelationID(m.Context())
+	}
+
+	mw := natsx.Chain(handler, middleware.CorrelationID("X-Request-ID", nil))
+
+	msg := &natsx.Msg{Msg: &natslib.Msg{
+		Subject: "test.cid.custom",
+		Header:  natslib.Header{"X-Request-ID": []string{"req-789"}},
+	}}
+	mw(msg)
+
+	if capturedCID != "req-789" {
+		t.Fatalf("expected cid=req-789, got %q", capturedCID)
+	}
+}
+
+func TestGetCorrelationIDEmpty(t *testing.T) {
+	cid := middleware.GetCorrelationID(context.Background())
+	if cid != "" {
+		t.Fatalf("expected empty cid, got %q", cid)
+	}
+}
+
+// ---------- ConcurrencyLimit ----------
+
+func TestConcurrencyLimit(t *testing.T) {
+	const maxConcurrent = 2
+	var current atomic.Int32
+	var peak atomic.Int32
+
+	handler := func(m *natsx.Msg) {
+		v := current.Add(1)
+		// Update peak concurrency.
+		for {
+			p := peak.Load()
+			if v <= p || peak.CompareAndSwap(p, v) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		current.Add(-1)
+	}
+
+	mw := natsx.Chain(handler, middleware.ConcurrencyLimit(maxConcurrent))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			msg := &natsx.Msg{Msg: &natslib.Msg{Subject: fmt.Sprintf("test.conc.%d", idx)}}
+			mw(msg)
+		}(i)
+	}
+	wg.Wait()
+
+	if p := peak.Load(); p > int32(maxConcurrent) {
+		t.Fatalf("peak concurrency %d exceeded limit %d", p, maxConcurrent)
+	}
+}
+
+// ---------- Validation ----------
+
+func TestValidationPass(t *testing.T) {
+	var called bool
+
+	validator := func(msg *natsx.Msg) error {
+		return nil // always valid
+	}
+
+	handler := func(m *natsx.Msg) {
+		called = true
+	}
+
+	mw := natsx.Chain(handler, middleware.Validation(validator, nil))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.valid"}}
+	mw(msg)
+
+	if !called {
+		t.Fatal("handler should have been called")
+	}
+}
+
+func TestValidationReject(t *testing.T) {
+	var handlerCalled bool
+	var rejectCalled bool
+	var rejectErr error
+
+	validator := func(msg *natsx.Msg) error {
+		return errors.New("invalid payload")
+	}
+
+	handler := func(m *natsx.Msg) {
+		handlerCalled = true
+	}
+
+	onReject := func(msg *natsx.Msg, err error) {
+		rejectCalled = true
+		rejectErr = err
+	}
+
+	mw := natsx.Chain(handler, middleware.Validation(validator, onReject))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.invalid"}}
+	mw(msg)
+
+	if handlerCalled {
+		t.Fatal("handler should NOT have been called")
+	}
+	if !rejectCalled {
+		t.Fatal("onReject should have been called")
+	}
+	if rejectErr == nil || rejectErr.Error() != "invalid payload" {
+		t.Fatalf("unexpected reject error: %v", rejectErr)
+	}
+}
+
+func TestValidationRejectNoCallback(t *testing.T) {
+	var handlerCalled bool
+
+	validator := func(msg *natsx.Msg) error {
+		return errors.New("bad")
+	}
+
+	handler := func(m *natsx.Msg) {
+		handlerCalled = true
+	}
+
+	mw := natsx.Chain(handler, middleware.Validation(validator, nil))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.reject.nocb"}}
+	mw(msg)
+
+	if handlerCalled {
+		t.Fatal("handler should NOT have been called")
+	}
+}
+
+// ---------- Metrics ----------
+
+type testMetrics struct {
+	mu        sync.Mutex
+	received  map[string]int
+	processed map[string]int
+	failed    map[string]int
+	durations map[string][]time.Duration
+}
+
+func newTestMetrics() *testMetrics {
+	return &testMetrics{
+		received:  make(map[string]int),
+		processed: make(map[string]int),
+		failed:    make(map[string]int),
+		durations: make(map[string][]time.Duration),
+	}
+}
+
+func (m *testMetrics) IncMessagesReceived(subject string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.received[subject]++
+}
+func (m *testMetrics) IncMessagesProcessed(subject string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processed[subject]++
+}
+func (m *testMetrics) IncMessagesFailed(subject string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failed[subject]++
+}
+func (m *testMetrics) ObserveDuration(subject string, d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.durations[subject] = append(m.durations[subject], d)
+}
+
+func TestMetricsSuccess(t *testing.T) {
+	rec := newTestMetrics()
+
+	handler := func(m *natsx.Msg) {}
+	mw := natsx.Chain(handler, middleware.Metrics(rec))
+
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.metrics"}}
+	mw(msg)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.received["test.metrics"] != 1 {
+		t.Fatalf("received=%d, want 1", rec.received["test.metrics"])
+	}
+	if rec.processed["test.metrics"] != 1 {
+		t.Fatalf("processed=%d, want 1", rec.processed["test.metrics"])
+	}
+	if rec.failed["test.metrics"] != 0 {
+		t.Fatalf("failed=%d, want 0", rec.failed["test.metrics"])
+	}
+	if len(rec.durations["test.metrics"]) != 1 {
+		t.Fatalf("duration records=%d, want 1", len(rec.durations["test.metrics"]))
+	}
+}
+
+func TestMetricsPanicDetection(t *testing.T) {
+	rec := newTestMetrics()
+
+	handler := func(m *natsx.Msg) {
+		panic("boom")
+	}
+
+	// Metrics alone — the panic should propagate through, but metrics are recorded.
+	mw := natsx.Chain(handler, middleware.Metrics(rec))
+
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.metrics.panic"}}
+
+	func() {
+		defer func() { recover() }()
+		mw(msg)
+	}()
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.received["test.metrics.panic"] != 1 {
+		t.Fatalf("received=%d, want 1", rec.received["test.metrics.panic"])
+	}
+	if rec.failed["test.metrics.panic"] != 1 {
+		t.Fatalf("failed=%d, want 1 (panic detected)", rec.failed["test.metrics.panic"])
+	}
+	if rec.processed["test.metrics.panic"] != 0 {
+		t.Fatalf("processed=%d, want 0 (panicked)", rec.processed["test.metrics.panic"])
+	}
+}
+
+func TestMetricsDurationRecorded(t *testing.T) {
+	rec := newTestMetrics()
+
+	handler := func(m *natsx.Msg) {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mw := natsx.Chain(handler, middleware.Metrics(rec))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.metrics.dur"}}
+	mw(msg)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if len(rec.durations["test.metrics.dur"]) != 1 {
+		t.Fatal("expected 1 duration record")
+	}
+	if rec.durations["test.metrics.dur"][0] < 15*time.Millisecond {
+		t.Fatalf("expected duration >= 15ms, got %v", rec.durations["test.metrics.dur"][0])
+	}
+}
+
+// ---------- Tracing ----------
+
+// simpleTracer implements middleware.Tracer for testing.
+type simpleTracer struct {
+	started  *atomic.Int32
+	finished *atomic.Int32
+}
+
+func (tr *simpleTracer) StartSpan(ctx context.Context, _ string, _ *natsx.Msg) (context.Context, middleware.SpanContext, func()) {
+	tr.started.Add(1)
+	sc := middleware.SpanContext{TraceID: "trace-001", SpanID: "span-001"}
+	return ctx, sc, func() { tr.finished.Add(1) }
+}
+
+func TestTracingMiddleware(t *testing.T) {
+	var started, finished atomic.Int32
+	tracer := &simpleTracer{started: &started, finished: &finished}
+
+	var capturedSC middleware.SpanContext
+
+	handler := func(m *natsx.Msg) {
+		capturedSC = middleware.GetSpanContext(m.Context())
+	}
+
+	mw := natsx.Chain(handler, middleware.Tracing(tracer, "test-op"))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.trace"}}
+	mw(msg)
+
+	if started.Load() != 1 {
+		t.Fatalf("expected 1 span started, got %d", started.Load())
+	}
+	if finished.Load() != 1 {
+		t.Fatalf("expected 1 span finished, got %d", finished.Load())
+	}
+	if capturedSC.TraceID != "trace-001" {
+		t.Fatalf("expected TraceID=trace-001, got %q", capturedSC.TraceID)
+	}
+	if capturedSC.SpanID != "span-001" {
+		t.Fatalf("expected SpanID=span-001, got %q", capturedSC.SpanID)
+	}
+}
+
+func TestGetSpanContextEmpty(t *testing.T) {
+	sc := middleware.GetSpanContext(context.Background())
+	if sc.TraceID != "" || sc.SpanID != "" {
+		t.Fatalf("expected empty SpanContext, got %+v", sc)
+	}
+}
+
+func TestTracingFinishCalledOnPanic(t *testing.T) {
+	var started, finished atomic.Int32
+	tracer := &simpleTracer{started: &started, finished: &finished}
+
+	handler := func(m *natsx.Msg) {
+		panic("handler panic")
+	}
+
+	mw := natsx.Chain(handler, middleware.Tracing(tracer, "panic-op"))
+	msg := &natsx.Msg{Msg: &natslib.Msg{Subject: "test.trace.panic"}}
+
+	func() {
+		defer func() { recover() }()
+		mw(msg)
+	}()
+
+	if finished.Load() != 1 {
+		t.Fatal("expected finish to be called even on panic")
+	}
+}

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/vsys-soham/natsx"
+)
+
+// Timeout returns a middleware that creates a context with the given deadline
+// for the handler. If the handler does not finish in time, a warning is logged.
+//
+// The deadline is attached to the message via WithContext, so handlers can
+// check msg.Context().Done() for cooperative cancellation.
+func Timeout(d time.Duration, log natsx.Logger) natsx.Middleware {
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			ctx, cancel := context.WithTimeout(msg.Context(), d)
+			defer cancel()
+
+			msg = msg.WithContext(ctx)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				next(msg)
+			}()
+
+			select {
+			case <-done:
+				// Handler completed before timeout.
+			case <-ctx.Done():
+				// Timeout exceeded — wait for handler to finish but log.
+				log.Warn("handler exceeded timeout",
+					"subject", msg.Subject,
+					"timeout", d.String(),
+				)
+				<-done
+			}
+		}
+	}
+}

--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/vsys-soham/natsx"
+)
+
+// SpanContext holds trace/span identifiers extracted or created by the tracing
+// middleware. This abstraction avoids a hard dependency on OpenTelemetry in
+// the middleware package — the actual OTel integration happens in the otel/ package.
+type SpanContext struct {
+	TraceID string
+	SpanID  string
+}
+
+// spanContextKey is the context key for SpanContext.
+type spanContextKey struct{}
+
+// Tracer is an interface for creating and extracting trace spans from NATS
+// message headers. Implement this interface to integrate with your tracing
+// backend (OpenTelemetry, Jaeger, Zipkin, etc.).
+type Tracer interface {
+	// StartSpan creates a new span for the given message. It should:
+	//   1. Extract any parent span from msg headers
+	//   2. Create a child span (or root span if no parent)
+	//   3. Return the span context and a finish function
+	//
+	// The finish function is called after the handler completes.
+	StartSpan(ctx context.Context, operationName string, msg *natsx.Msg) (context.Context, SpanContext, func())
+}
+
+// Tracing returns a middleware that creates a trace span for each message.
+// The span context is stored in the message context and can be retrieved
+// with GetSpanContext().
+func Tracing(tracer Tracer, operationName string) natsx.Middleware {
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			ctx, sc, finish := tracer.StartSpan(msg.Context(), operationName, msg)
+			defer finish()
+
+			ctx = context.WithValue(ctx, spanContextKey{}, sc)
+			msg = msg.WithContext(ctx)
+			next(msg)
+		}
+	}
+}
+
+// GetSpanContext extracts the SpanContext from a context.
+// Returns a zero-value SpanContext if none is set.
+func GetSpanContext(ctx context.Context) SpanContext {
+	if v, ok := ctx.Value(spanContextKey{}).(SpanContext); ok {
+		return v
+	}
+	return SpanContext{}
+}
+
+// NopTracer is a no-op Tracer implementation. Useful for tests.
+type NopTracer struct{}
+
+func (NopTracer) StartSpan(ctx context.Context, _ string, _ *natsx.Msg) (context.Context, SpanContext, func()) {
+	return ctx, SpanContext{}, func() {}
+}

--- a/middleware/validation.go
+++ b/middleware/validation.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"github.com/vsys-soham/natsx"
+)
+
+// Validator is a function that validates a message before it reaches the handler.
+// Return a non-nil error to reject the message.
+type Validator func(msg *natsx.Msg) error
+
+// Validation returns a middleware that runs a validator function before calling
+// the handler. If the validator returns an error, the message is rejected and
+// the handler is not called.
+//
+// The optional onReject callback is invoked with the message and error when
+// validation fails. Use it to log, Nak, or send the message to a DLQ.
+func Validation(validate Validator, onReject func(msg *natsx.Msg, err error)) natsx.Middleware {
+	return func(next natsx.MsgHandler) natsx.MsgHandler {
+		return func(msg *natsx.Msg) {
+			if err := validate(msg); err != nil {
+				if onReject != nil {
+					onReject(msg, err)
+				}
+				return
+			}
+			next(msg)
+		}
+	}
+}


### PR DESCRIPTION
- Timeout — wraps handler with context.WithTimeout
- Metrics — counters (messages processed, errors) + histogram (duration)
- Tracing — creates/continues OpenTelemetry spans from headers
- CorrelationID — extracts/injects X-Correlation-ID header
- ConcurrencyLimit — semaphore-based max in-flight messages
- Validation — runs a func(*Msg) error before handler